### PR TITLE
FIX: Capture the URL type error

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -387,7 +387,7 @@
         }
 
         function parseExtension(url) {
-            var match = /\.([^\.\/]*?)$/g.exec(url);
+            var match = /\.([^\.\/]*?)(\?|$)/g.exec(url);
             if (match) return match[1];
             else return '';
         }


### PR DESCRIPTION
When a URL pattern has a query string the file-extension isn't matched correctly IFF the URL has `.` in the query parameters.