### PR TITLE
Fix cloning SVGAnimatedString

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -258,7 +258,11 @@
                     if (content === '' || content === 'none') return;
 
                     var className = util.uid();
-                    clone.className = clone.className + ' ' + className;
+                    var currentClass = clone.getAttribute('class');
+                    if (currentClass) {
+                        clone.setAttribute('class', currentClass + ' ' + className);
+                    }
+
                     var styleElement = document.createElement('style');
                     styleElement.appendChild(formatPseudoElementStyle(className, element, style));
                     clone.appendChild(styleElement);


### PR DESCRIPTION
> className can also be an instance of SVGAnimatedString if the element is an SVGElement. It is better to get/set the className of an element using Element.getAttribute and Element.setAttribute if you are dealing with SVG elements.

https://developer.mozilla.org/en-US/docs/Web/API/Element/className#Notes

SVGElement's className is not a string and thus we currently set an invalid class (eg. [object SVGAnimatedString] udfqi3) when cloning this kind of elements.
Also it cannot be reassigned directly as it is a read-only property.

Using the provided getAttribute/setAttribute solve those problems.

Fixes: https://github.com/tsayen/dom-to-image/issues/247
Cloned from PR: https://github.com/tsayen/dom-to-image/pull/250