### PR TITLE
fix font mangling

### DIFF
--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -252,10 +252,27 @@
             function cloneStyle() {
                 copyStyle(window.getComputedStyle(original), clone.style);
 
+                function copyFont(source, target) {
+                    target.font = source.font;
+                    target.fontFamily = source.fontFamily;
+                    target.fontFeatureSettings = source.fontFeatureSettings;
+                    target.fontKerning = source.fontKerning;
+                    target.fontSize = source.fontSize;
+                    target.fontStretch = source.fontStretch;
+                    target.fontStyle = source.fontStyle;
+                    target.fontVariant = source.fontVariant;
+                    target.fontVariantCaps = source.fontVariantCaps;
+                    target.fontVariantEastAsian = source.fontVariantEastAsian;
+                    target.fontVariantLigatures = source.fontVariantLigatures;
+                    target.fontVariantNumeric = source.fontVariantNumeric;
+                    target.fontVariationSettings = source.fontVariationSettings;
+                    target.fontWeight = source.fontWeight;
+                }
+
                 function copyStyle(source, target) {
                     if (source.cssText) {
                         target.cssText = source.cssText;
-                        target.font = source.font; // here, we re-assign the font prop.
+                        copyFont(source, target); // here we re-assign the font props.
                     } else copyProperties(source, target);
 
                     function copyProperties(source, target) {


### PR DESCRIPTION
In various circumstances, the `source.font` prop can be null, causing the rendered image to have a mangled font.

For one example that causes this, try setting the style `font-variant-liagatures: none`. The solution I found is to copy every single font property over, which will cause the fonts to render correctly in every situation.