### PR TITLE
Remove default styles

### DIFF
--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -168,6 +168,8 @@
      * @return {Promise} - A promise that is fulfilled with a canvas object
      * */
     function toCanvas(node, options) {
+        options = options || {};
+        options.raster = true;
         return draw(node, options || {});
     }
 

--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -14,7 +14,7 @@
         cacheBust: false,
         // Use (existing) authentication credentials for external URIs (CORS requests)
         useCredentials: false,
-        // Default resolve timeout 
+        // Default resolve timeout
         httpTimeout: 30000
     };
 
@@ -57,7 +57,7 @@
      * @param {Object} options.style - an object whose properties to be copied to node's style before rendering.
      * @param {Number} options.quality - a Number between 0 and 1 indicating image quality (applicable to JPEG only),
                 defaults to 1.0.
-     * @param {Booolean} options.raster - Used internally to track whether the output is a raster image not requiring CSS reduction.
+     * @param {Boolean} options.raster - Used internally to track whether the output is a raster image not requiring CSS reduction.
      * @param {Number} options.scale - a Number multiplier to scale up the canvas before rendering to reduce fuzzy images, defaults to 1.0.
      * @param {String} options.imagePlaceholder - dataURL to use as a placeholder for failed images, default behaviour is to fail fast on images we can't fetch
      * @param {Boolean} options.cacheBust - set to true to cache bust by appending the time to the request url
@@ -207,6 +207,7 @@
                     ctx.scale(scale, scale);
                     ctx.drawImage(image, 0, 0);
                 }
+                removeSandbox();
                 return canvas;
             });
 
@@ -225,7 +226,7 @@
         }
     }
 
-    function cloneNode(node, filter, root, vector) {
+    function cloneNode(node, filter, root, vector, parentComputedStyles = null) {
         if (!root && filter && !filter(node)) return Promise.resolve();
 
         return Promise.resolve(node)
@@ -258,11 +259,12 @@
                 });
 
             function cloneChildrenInOrder(parent, childs) {
+                var computedStyles = getComputedStyle(original);
                 var done = Promise.resolve();
                 childs.forEach(function(child) {
                     done = done
                         .then(function() {
-                            return cloneNode(child, filter, false, vector);
+                            return cloneNode(child, filter, false, vector, computedStyles);
                         })
                         .then(function(childClone) {
                             if (childClone) parent.appendChild(childClone);
@@ -285,11 +287,7 @@
                 });
 
             function cloneStyle() {
-                if (vector) {
-                    copyStyle(getUserComputedStyle(original, root), clone.style);
-                } else {
-                    copyStyle(getComputedStyle(original), clone.style);
-                }
+                copyStyle(original, clone);
 
                 function copyFont(source, target) {
                     target.font = source.font;
@@ -308,27 +306,25 @@
                     target.fontWeight = source.fontWeight;
                 }
 
-                function copyStyle(source, target) {
-                    if (source.cssText) {
-                        target.cssText = source.cssText;
-                        copyFont(source, target); // here we re-assign the font props.
-                    } else copyProperties(source, target);
-
-                    function copyProperties(from, to) {
-                        util.asArray(from).forEach(function(name) {
-                            to.setProperty(
-                                name,
-                                from.getPropertyValue(name),
-                                from.getPropertyPriority(name)
-                            );
-                        });
+                function copyStyle(sourceElement, targetElement) {
+                    var sourceComputedStyles = getComputedStyle(sourceElement);
+                    if (sourceComputedStyles.cssText) {
+                        targetElement.style.cssText = sourceComputedStyles.cssText;
+                        copyFont(sourceComputedStyles, targetElement.style); // here we re-assign the font props.
+                    } else {
+                        if (vector) {
+                            copyUserComputedStyle(sourceElement, sourceComputedStyles, targetElement, root);
+                        } else {
+                            copyUserComputedStyleFast(sourceComputedStyles, parentComputedStyles, targetElement);
+                        }
 
                         // Remove positioning of root elements, which stops them from being captured correctly
                         if (root) {
-                            ['inset-block', 'inset-block-start', 'inset-block-end'].forEach((prop) => target.removeProperty(prop));
+                            ['inset-block', 'inset-block-start', 'inset-block-end']
+                              .forEach((prop) => targetElement.style.removeProperty(prop));
                             ['left', 'right', 'top', 'bottom'].forEach((prop) => {
-                                if (target.getPropertyValue(prop)) {
-                                    target.setProperty(prop, '0px');
+                                if (targetElement.style.getPropertyValue(prop)) {
+                                    targetElement.style.setProperty(prop, '0px');
                                 }
                             });
                         }
@@ -870,27 +866,97 @@
         }
     }
 
-    function getUserComputedStyle(element, root) {
-        var clonedStyle = document.createElement(element.tagName).style;
-        var computedStyles = getComputedStyle(element);
-        var inlineStyles = element.style;
+    // `copyUserComputedStyle` and `copyUserComputedStyleFast` copy element styles, omitting defaults to reduce memory
+    // consumption. The former is slow and omits all defaults, while the latter is faster and omits most defaults. Out
+    // of ~340 CSS rules, usually <=10 are set, so it makes sense to only copy what we need. By omitting defaults, the
+    // data URI is <=10% of the original length, which means we can capture pages 10 times as complex before hitting
+    // the Firefox 97+ data URI max length, which is 32 MB. In addition, generated SVGs are much more performant.
+    // See https://stackoverflow.com/questions/42025329/how-to-get-the-applied-style-from-an-element.
+    function copyUserComputedStyle(sourceElement, sourceComputedStyles, targetElement, root) {
+        var targetStyle = targetElement.style;
+        var inlineStyles = sourceElement.style;
 
-        for (var style of computedStyles) {
-            var value = computedStyles.getPropertyValue(style);
+        for (var style of sourceComputedStyles) {
+            var value = sourceComputedStyles.getPropertyValue(style);
             var inlineValue = inlineStyles.getPropertyValue(style);
 
             inlineStyles.setProperty(style, root ? 'initial' : 'unset');
-            var initialValue = computedStyles.getPropertyValue(style);
+            var initialValue = sourceComputedStyles.getPropertyValue(style);
 
             if (initialValue !== value) {
-                clonedStyle.setProperty(style, value);
+                targetStyle.setProperty(style, value);
             } else {
-                clonedStyle.removeProperty(style);
+                targetStyle.removeProperty(style);
             }
 
             inlineStyles.setProperty(style, inlineValue);
         }
-
-        return clonedStyle;
     }
+
+    function copyUserComputedStyleFast(sourceComputedStyles, parentComputedStyles, targetElement) {
+        var defaultStyle = getDefaultStyle(targetElement.tagName);
+        var targetStyle = targetElement.style;
+
+        util.asArray(sourceComputedStyles).forEach(function(name) {
+            var sourceValue = sourceComputedStyles.getPropertyValue(name);
+            // If the style does not match the default, or it does not match the parent's, set it. We don't know which
+            // styles are inherited from the parent and which aren't, so we have to always check both.
+            if (sourceValue !== defaultStyle[name] ||
+              (parentComputedStyles && sourceValue !== parentComputedStyles.getPropertyValue(name))) {
+                targetStyle.setProperty(name, sourceValue, sourceComputedStyles.getPropertyPriority(name));
+            }
+        });
+    }
+
+    var removeDefaultStylesTimeoutId = null;
+    var sandbox = null;
+    var tagNameDefaultStyles = {};
+
+    function getDefaultStyle(tagName) {
+        if (tagNameDefaultStyles[tagName]) {
+            return tagNameDefaultStyles[tagName];
+        }
+        if (!sandbox) {
+            // Create a hidden sandbox <iframe> element within we can create default HTML elements and query their
+            // computed styles. Elements must be rendered in order to query their computed styles. The <iframe> won't
+            // render at all with `display: none`, so we have to use `visibility: hidden` with `position: fixed`.
+            sandbox = document.createElement('iframe');
+            sandbox.style.visibility = 'hidden';
+            sandbox.style.position = 'fixed';
+            document.body.appendChild(sandbox);
+            // Ensure that the iframe is rendered in standard mode
+            sandbox.contentWindow.document.write('<!DOCTYPE html><meta charset="UTF-8"><title>sandbox</title><body>');
+        }
+        var defaultElement = document.createElement(tagName);
+        sandbox.contentWindow.document.body.appendChild(defaultElement);
+        // Ensure that there is some content, so that properties like margin are applied.
+        defaultElement.textContent = '.';
+        var defaultComputedStyle = sandbox.contentWindow.getComputedStyle(defaultElement);
+        var defaultStyle = {};
+        // Copy styles to an object, making sure that 'width' and 'height' are given the default value of 'auto', since
+        // their initial value is always 'auto' despite that the default computed value is sometimes an absolute length.
+        util.asArray(defaultComputedStyle).forEach(function(name) {
+            defaultStyle[name] =
+              (name === 'width' || name === 'height') ? 'auto' : defaultComputedStyle.getPropertyValue(name);
+        });
+        sandbox.contentWindow.document.body.removeChild(defaultElement);
+        tagNameDefaultStyles[tagName] = defaultStyle;
+        return defaultStyle;
+    }
+
+    function removeSandbox() {
+        if (!sandbox) {
+            return;
+        }
+        document.body.removeChild(sandbox);
+        sandbox = null;
+        if (removeDefaultStylesTimeoutId) {
+            clearTimeout(removeDefaultStylesTimeoutId);
+        }
+        removeDefaultStylesTimeoutId = setTimeout(() => {
+            removeDefaultStylesTimeoutId = null;
+            tagNameDefaultStyles = {};
+        }, 20*1000);
+    }
+
 })(this);


### PR DESCRIPTION
getComputedStyle returns about 340 CSS styles for an element, almost all of which are default styles. According to my tests, omitting these default styles from the raster image captures makes screenshots 60% faster and shortens the image data URIs by 11x in length. (By "raster" I mean the types of captures not requiring CSS reduction, i.e. all methods besides `toSvg`, which shortens CSS styles even further but takes much longer to do so).

This is similar to [PR #37](https://github.com/1904labs/dom-to-image-more/pull/37) (which added the CSS reduction for `toSvg`), but the code caches the default styles for each type of HTML element, so the calculations are significantly faster and actually speed up screen captures.

This would close #70. It also helps close [dom-to-image #245](https://github.com/tsayen/dom-to-image/issues/245).

**Performance comparisons according to local tests:**

Test case: Capture a webpage with 5675 HTML elements using `toBlob`, which generates a raster image (does not use CSS reduction).

Baseline: The task took 7.9 seconds (average between Firefox, Chrome, and Edge), which involved copying 1929500 styles (340 per element) from the webpage to the clone being captured. The clone's data URI length was 32561735 characters (31.1 MB).

With this PR: The task takes 3.1 seconds, which involves copying 39051 styles (6.9 per element) from the webpage to the clone. The clone's data URI length is 2843600 characters (2.7 MB). This is 60% faster, has 49x less styles to copy, and the data URI length is 11x shorter in length.

Test case: Same as above, but capture using `toSvg`, which generates a non-raster image (uses CSS reduction). This task uses the CSS reduction code from [PR #37](https://github.com/1904labs/dom-to-image-more/pull/37), which has not been altered significantly by the PR. The baseline, as well as the performance with this PR is the same: The task takes 38.5 seconds, which involves copying 24374 styles (3.5 per element) from the webpage to the clone being captured. The clone's data URI length is 2174916 characters (2.1 MB), which is 15x shorter than the `toBlob` baseline, at the expense of 5x longer compute time.

**Implementation details**

For the raster image captures (all methods besides `toSvg`), the code uses a new `copyUserComputedStyleFast` function to copy styles from an HTML node to the clone. `copyUserComputedStyleFast` first obtains the default styles for HTML elements with the same tag name as the node being copied. (It does this by querying the computed styles for an HTML element within a hidden `<iframe>`. The default styles are identical to the computed styles, except an adjustment we make for `width` and `height` - see note [1] below.) It compares the node with the default element styles, then only copies the styles that differ to the clone.

For the non-raster image captures (`toSvg`), the code uses a new `copyUserComputedStyle` function in place of the previous `getUserComputedStyle`. The previous function obtained the non-default styles for an HTML element, then assigned these styles to a dummy DOM element so it could return them. The new function is equivalent, except it no longer needs to assign styles to a dummy DOM element since it only copies (not returns) styles. This might be a tad bit faster, although performance was identical in my tests.

*One more minor change:* Before this PR, `toCanvas` used CSS reduction, which I assumed was accidental, so I changed it to not require CSS reduction.

How does the Node environment differ from the browser environment? I'm asking because the code uses `iframe.contentWindow.document.body` and `iframe.contentWindow.getComputedStyle` while getting the default styles, which works great on Firefox, Edge, and Chrome (see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/contentWindow)). I'm not sure whether a different syntax is needed for Node. Feel free to change any implementation details of this PR. Thanks for all your work on this amazing library!

[1]:  For block elements, `width`, `height`, `block-size`, `inset-block`, `transform-origin`, and `perspective-origin` are "special" in that the initial and computed values don't match. Let me explain. For example, for `width` and `height`, the default style (initial value) is always `auto`. However, the computed value (as returned by `getComputedStyle`) is an absolute value measured in `px`. If the code returned this as the default style, then it wouldn't clone `width` for certain nodes (block elements with a set width that matched the measurement), which would be a bug. The same goes for `height` and the other 4 CSS properties listed above. To remedy this, the code returns `auto` as the default style for `width` and `height`, since that is always the initial value. The other 4 CSS properties are used infrequently, and the likelihood that they would be used and happen to match the measurement is very slim, so the code doesn't remedy the issue for them. If you do want to make the code more robust to accommodate these (very rare) situations, let me know and I'd be happy to change the PR to return the initial value for these other 4 properties as well. This could be done programmatically, for example, by simply creating two HTML elements in the hidden `<iframe>` instead of one, of different sizes, and only returning the default styles that matched between the two elements.