### PR TITLE
Fix background images not being loaded

### DIFF
--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -873,7 +873,7 @@
         function inlineAll(node) {
             if (!(node instanceof Element)) { return Promise.resolve(node); }
 
-            return inlineBackground(node)
+            return inlineCSSProperty(node)
                 .then(function () {
                     if (node instanceof HTMLImageElement) {
                         return newImage(node).inline();
@@ -886,22 +886,23 @@
                     }
                 });
 
-            function inlineBackground(backgroundNode) {
+            function inlineCSSProperty(node) {
                 const properties = ['background', 'background-image'];
 
                 const inliningTasks = properties.map(function (propertyName) {
-                    const value = backgroundNode.style.getPropertyValue(propertyName);
+                    const value = node.style.getPropertyValue(propertyName);
+                    const priority = node.style.getPropertyPriority(propertyName);
 
                     if(!value) {
                         return Promise.resolve();
                     }
 
                     return inliner.inlineAll(value)
-                        .then(function (inlined) {
-                            backgroundNode.style.setProperty(
+                        .then(function (inlinedValue) {
+                            node.style.setProperty(
                                 propertyName,
-                                inlined,
-                                backgroundNode.style.getPropertyPriority(propertyName)
+                                inlinedValue,
+                                priority
                             );
                         });
                 });

--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -887,18 +887,26 @@
                 });
 
             function inlineBackground(backgroundNode) {
-                const background = backgroundNode.style.getPropertyValue('background');
+                const properties = ['background', 'background-image'];
 
-                if (!background) { return Promise.resolve(backgroundNode); }
+                const inliningTasks = properties.map(function (propertyName) {
+                    const value = backgroundNode.style.getPropertyValue(propertyName);
 
-                return inliner.inlineAll(background)
-                    .then(function (inlined) {
-                        backgroundNode.style.setProperty(
-                            'background',
-                            inlined,
-                            background
-                        );
-                    })
+                    if(!value) {
+                        return Promise.resolve();
+                    }
+
+                    return inliner.inlineAll(value)
+                        .then(function (inlined) {
+                            backgroundNode.style.setProperty(
+                                propertyName,
+                                inlined,
+                                backgroundNode.style.getPropertyPriority(propertyName)
+                            );
+                        });
+                });
+
+                return Promise.all(inliningTasks)
                     .then(function () {
                         return backgroundNode;
                     });


### PR DESCRIPTION
Fixes 1904labs/dom-to-image-more#72 (thanks @yuyanan58 for the suggested fix)

Also adds support for background-image property. This is also extensible to any other CSS properties which we might want to support in future.