### PR TITLE
Filter out sandbox iframe from clone tree

### DIFF
--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -957,7 +957,7 @@
         const defaultElement = document.createElement(tagName);
         sandbox.contentWindow.document.body.appendChild(defaultElement);
         // Ensure that there is some content, so that properties like margin are applied.
-        defaultElement.textContent = '.';
+        defaultElement.textContent = ';';
         const defaultComputedStyle = sandbox.contentWindow.getComputedStyle(defaultElement);
         const defaultStyle = {};
         // Copy styles to an object, making sure that 'width' and 'height' are given the default value of 'auto', since

--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -45,6 +45,11 @@
     const getComputedStyle = global.getComputedStyle || window.getComputedStyle;
     const atob = global.atob || window.atob;
 
+    // hoisted getDefaultStyle() variables
+    let removeDefaultStylesTimeoutId = null;
+    let sandbox = null;
+    let tagNameDefaultStyles = {};
+
     /**
      * @param {Node} node - The DOM Node object to render
      * @param {Object} options - Rendering options
@@ -236,7 +241,7 @@
     }
 
     function cloneNode(node, filter, root, parentComputedStyles, ownerWindow) {
-        if (!root && filter && !filter(node)) {
+        if (!root && (filter && !filter(node) || node === sandbox)) {
             return Promise.resolve();
         }
 
@@ -930,10 +935,6 @@
             }
         });
     }
-
-    let removeDefaultStylesTimeoutId = null;
-    let sandbox = null;
-    let tagNameDefaultStyles = {};
 
     function getDefaultStyle(tagName) {
         if (tagNameDefaultStyles[tagName]) {


### PR DESCRIPTION
Sometimes the sandbox iframe can appear in the clone.. if its in the DOM tree of `node` in `toSvg()` for example.
Let's make sure the iframe isn't cloned, just as an output linting + data saving measure.

NB: we *could* be thinking about sane defaults to filter `iframe` `script` `link` and `style`, but the developer can work around issue(s) as they arise using `options.filter`.