### PR TITLE
Fix quirks mode regression

### DIFF
--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -89,6 +89,7 @@
 
         function clearCache(result) {
             domtoimage.impl.urlCache = [];
+            removeSandbox();
             return result;
         }
 
@@ -224,7 +225,6 @@
                     ctx.scale(scale, scale);
                     ctx.drawImage(image, 0, 0);
                 }
-                removeSandbox();
                 return canvas;
             });
 

--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -1218,6 +1218,7 @@
                 }
                 if (!isTrustedTypesRequired) {
                     const sandboxDocument = document.implementation.createHTMLDocument(sandbox.id);
+                    sandboxDocument.head.appendChild(charset);
                     const sandboxDoctype = document.doctype ? '<!DOCTYPE html>' : '';
                     const sandboxHTML = `${sandboxDoctype}${sandboxDocument.documentElement.outerHTML}`;
                     sandbox.setAttribute('srcdoc', sandboxHTML);

--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -1208,10 +1208,10 @@
                 // If the parent document has a Trusted Types policy, fallback to quirks mode.
                 let isTrustedTypesRequired;
                 try {
-                    const xhr = new XMLHttpRequest();
-                    xhr.open('GET', document.location.href, false);
-                    xhr.send();
-                    const csp = xhr.getResponseHeader('content-security-policy');
+                    const request = new XMLHttpRequest();
+                    request.open('HEAD', document.location.href, false);
+                    request.send();
+                    const csp = request.getResponseHeader('content-security-policy');
                     isTrustedTypesRequired = csp.indexOf('require-trusted-types-for') !== -1;
                 } catch(_) {
                     isTrustedTypesRequired = true;

--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -1199,7 +1199,7 @@
                 sandbox.style.visibility = 'hidden';
                 sandbox.style.position = 'fixed';
                 document.body.appendChild(sandbox);
-                sandbox.id = sandbox.contentDocument.title = 'domtoimage-sandbox';
+                sandbox.id = sandbox.contentDocument.title = 'domtoimage-sandbox-' + util.uid();
                 // Ensure the iframe's character rendering matches the document (with UTF-8 fallback).
                 const charset = document.createElement('meta');
                 charset.setAttribute('charset', document.characterSet || 'UTF-8');
@@ -1220,7 +1220,7 @@
                     const sandboxDocument = document.implementation.createHTMLDocument(sandbox.id);
                     sandboxDocument.head.appendChild(charset);
                     const sandboxDoctype = document.doctype ? '<!DOCTYPE html>' : '';
-                    const sandboxHTML = `${sandboxDoctype}${sandboxDocument.documentElement.outerHTML}`;
+                    const sandboxHTML = sandboxDoctype + sandboxDocument.documentElement.outerHTML;
                     sandbox.setAttribute('srcdoc', sandboxHTML);
                 }
             }

--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -1204,7 +1204,8 @@
                 const charset = document.createElement('meta');
                 charset.setAttribute('charset', document.characterSet || 'UTF-8');
                 sandbox.contentDocument.head.appendChild(charset);
-                // If the parent document lacks a Trusted Types policy, fallback to quirks mode.
+                // Ensure the document is rendered in standard mode by coercing doctype.
+                // If the parent document has a Trusted Types policy, fallback to quirks mode.
                 let isTrustedTypesRequired;
                 try {
                     const xhr = new XMLHttpRequest();
@@ -1216,7 +1217,6 @@
                     isTrustedTypesRequired = true;
                 }
                 if (!isTrustedTypesRequired) {
-                    // Ensure the document is rendered in standard mode by coercing doctype.
                     const sandboxDocument = document.implementation.createHTMLDocument(sandbox.id);
                     const sandboxDoctype = document.doctype ? '<!DOCTYPE html>' : '';
                     const sandboxHTML = `${sandboxDoctype}${sandboxDocument.documentElement.outerHTML}`;


### PR DESCRIPTION
- We have a significant regression so we need to ~~revert~~ handle #100.
  The only other method of fixing this one is `srcdoc` and that's included in the Trusted Types policy.
- The raster image methods were self-cleaning since #71.
  Per #70 comments, let's run it in `toSvg` to make sure sandbox is killed in all cases.