### PR TITLE
Workaround for Firefox bug (fixes #123)

### DIFF
--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -738,6 +738,13 @@
                     image.crossOrigin = 'use-credentials';
                 }
                 image.onload = function () {
+                    if(typeof window === "undefined" || !window.requestAnimationFrame) {
+                        // NodeJS doesn't have a requestAnimationFrame function and may not have a window object.
+                        // NodeJS also presumably doesn't exhibit this Firefox bug though, so in this case we can proceed immediately.
+                        resolve(image);
+                        return;
+                    }
+
                     // In order to work around a Firefox bug (webcompat/web-bugs#119834) we
                     // need to wait one extra frame before it's safe to read the image data.
                     window.requestAnimationFrame(function() {

--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -738,7 +738,11 @@
                     image.crossOrigin = 'use-credentials';
                 }
                 image.onload = function () {
-                    resolve(image);
+                    // In order to work around a Firefox bug (webcompat/web-bugs#119834) we
+                    // need to wait one extra frame before it's safe to read the image data.
+                    window.requestAnimationFrame(function() {
+                        resolve(image);
+                    });
                 };
                 image.onerror = reject;
                 image.src = uri;


### PR DESCRIPTION
This is a workaround for Firefox bug webcompat/web-bugs#119834. Waiting one extra frame here ensures that the image is fully rendered before we read the data from it.