### PR TITLE
Prevent overriding styles on clone node if already style exists

### DIFF
--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -1258,6 +1258,10 @@
                 ? parentComputedStyles.getPropertyValue(name)
                 : undefined;
 
+            // Ignore setting style property on clone node, if already it has a style (through adjustCloneNode)
+            const targetValue = targetStyle.getPropertyValue(name);
+            if(targetValue) return;   
+
             // If the style does not match the default, or it does not match the parent's, set it. We don't know which
             // styles are inherited from the parent and which aren't, so we have to always check both.
             if (


### PR DESCRIPTION
Primarily solves https://github.com/1904labs/dom-to-image-more/issues/170

Also seems it essential to **not** override (or reset) styles which are already got override through `adjustCloneNode` from `options`. so this PR prevents that reset if clone node has a style property already.

@IDisposable