### PR TITLE
Update README.md TypesScript instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ taken:
 
     ```javascript
     declare module 'dom-to-image-more' {
-     import domToImage = require('dom-to-image-more');
+     import domToImage = require('dom-to-image');
      export = domToImage;
     }
     ```


### PR DESCRIPTION
The typescript instructions have a typo in them, this change makes it work for me

May be related to this:
https://github.com/1904labs/dom-to-image-more/pull/140