### PR TITLE
Fix URL regex rules, solving most font icon URL replacement issues

### DIFF
--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -950,7 +950,7 @@
         }
 
         function escapeRegEx(string) {
-            return string.replace(/([.*+?^${}()|[]\/\\])/g, '\\$1');
+            return string.replace(/([.*+?^${}()|[\]\/\\])/g, '\\$1');
         }
 
         function delay(ms) {


### PR DESCRIPTION
Before:

```
"https://fonts.gstatic.com/s/xx/vxx/xx.woff2".replace(/([.*+?^${}()|[]\/\\])/g, '\\$1')
'https://fonts.gstatic.com/s/xx/vxx/xx.woff2'
```
Didn't work
![image](https://github.com/user-attachments/assets/8838e30b-c636-461c-9cf6-a4592565ab63)

After:
```

"https://fonts.gstatic.com/s/xx/vxx/xx.woff2".replace(/([.*+?^${}()|[\]\/\\])/g, '\\$1')
'https:\\/\\/fonts\\.gstatic\\.com\\/s\\/xx\\/vxx\\/xx\\.woff2'
```

![image](https://github.com/user-attachments/assets/56856063-e7d5-49ce-a7d6-15c36b865c64)
