### PR TITLE
fix:url not match correctly when the url include brackets

### DIFF
--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -1032,7 +1032,7 @@
     }
 
     function newInliner() {
-        const URL_REGEX = /url\(['"]?([^'"]+?)['"]?\)/g;
+        const URL_REGEX = /url\((['"]?)([^'"]+?)\1\)/g;
 
         return {
             inlineAll: inlineAll,
@@ -1051,7 +1051,7 @@
             const result = [];
             let match;
             while ((match = URL_REGEX.exec(string)) !== null) {
-                result.push(match[1]);
+                result.push(match[2]);
             }
             return result.filter(function (url) {
                 return !util.isDataUrl(url);


### PR DESCRIPTION
We are using **dom-to-image-more** in an electron app. So all the resources are loaded from the local file system. We found that the 'URL_REGEX' not handle the url correctly when the url include brackets.
such as: 
```css
@font-face { font-family: codicon; font-display: block; src: url("file:///C:/Program%20Files%20(x86)/<app>/resources/app/lib/frontend/front.ttf") format("truetype"); }
```
The solution is that matching the quote in the first place after left bracket and should be matched before right bracket.
