### PR TITLE
feat: New option to filter the URLs to be inlined

### DIFF
--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -1150,10 +1150,6 @@
                 .then(selectWebFontRules)
                 .then(function (rules) {
                     return rules.map(newWebFont);
-                })
-                .then(function (webFonts) {
-                    if (!domtoimage.impl.options.filterFonts) return webFonts;
-                    return webFonts.filter(domtoimage.impl.options.filterFonts)
                 });
 
             function selectWebFontRules(cssRules) {

--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -28,6 +28,8 @@
         adjustClonedNode: undefined,
         // Callback to filter style properties to be included in the output
         filterStyles: undefined,
+        // Callback to filter urls to be downloaded and inlined in the output
+        filterUrls: undefined,
     };
 
     const domtoimage = {
@@ -307,6 +309,12 @@
             domtoimage.impl.options.styleCaching = defaultOptions.styleCaching;
         } else {
             domtoimage.impl.options.styleCaching = options.styleCaching;
+        }
+
+        if (typeof options.filterUrls === 'undefined') {
+            domtoimage.impl.options.filterUrls = defaultOptions.filterUrls;
+        } else {
+            domtoimage.impl.options.filterUrls = options.filterUrls;
         }
     }
 
@@ -1093,6 +1101,12 @@
             return Promise.resolve(string)
                 .then(readUrls)
                 .then(function (urls) {
+                    if (!domtoimage.impl.options.filterUrls) return urls;
+                    return urls.filter(function (url) {
+                        return domtoimage.impl.options.filterUrls(url, baseUrl)
+                    });
+                })
+                .then(function (urls) {
                     let done = Promise.resolve(string);
                     urls.forEach(function (url) {
                         done = done.then(function (prefix) {
@@ -1136,6 +1150,10 @@
                 .then(selectWebFontRules)
                 .then(function (rules) {
                     return rules.map(newWebFont);
+                })
+                .then(function (webFonts) {
+                    if (!domtoimage.impl.options.filterFonts) return webFonts;
+                    return webFonts.filter(domtoimage.impl.options.filterFonts)
                 });
 
             function selectWebFontRules(cssRules) {


### PR DESCRIPTION
Based on my issue described in #219 

## Changes

- Add new `options.filterUrls` callback

## Usage

The callback takes the inlined URL (which might be just the filename or an absolute URL) and the base URL which represents the resource/source of the URL.

```ts
options.filterUrls = (inlineUrl: string, baseUrl: string | null) => {
  // Perform check on whether or not to filter out the inlined URL
  return true;
}
```

## Motivating Example: Font Awesome

See my linked discussion above for my approach, but this significantly improves performance and network transfer when inlining.