### PR TITLE
Inline nested SVG <image> href

### DIFF
--- a/spec/dom-to-image-more.spec.js
+++ b/spec/dom-to-image-more.spec.js
@@ -449,6 +449,41 @@
                     .catch(done);
             });
 
+            it('inlines a nested SVG <image> href (#121)', function (done) {
+                // An SVG <image> references its bitmap via href / xlink:href (not .src
+                // like an HTML <img>), so it must be fetched and embedded as a data URL
+                // too, or it survives as an unfetchable external URL in the output.
+                this.timeout(15000);
+                const url = '/base/spec/resources/images/image.png';
+                loadTestPage()
+                    .then(function () {
+                        domNode().innerHTML =
+                            '<svg width="40" height="40" xmlns="http://www.w3.org/2000/svg">' +
+                            '<image id="img" href="' +
+                            url +
+                            '" width="40" height="40"></image>' +
+                            '</svg>';
+                        return renderToSvg(domNode());
+                    })
+                    .then(function (svg) {
+                        const decoded = decodeURIComponent(svg);
+                        const image = (decoded.match(/<image[^>]*>/) || [])[0];
+                        assert.isString(image, '<image> should be in the output');
+                        assert.include(
+                            image,
+                            'data:image',
+                            'the SVG <image> href must be inlined as a data: URL'
+                        );
+                        assert.notInclude(
+                            image,
+                            'image.png',
+                            'the external href must not survive in the output'
+                        );
+                    })
+                    .then(done)
+                    .catch(done);
+            });
+
             // #191: a CSS `url()` set via options.style (the browser normalizes it to
             // double quotes) was serialized inside the double-quoted style attribute as
             // `url(&quot;…&quot;)`. We now emit clean single-quoted `url('…')`.

--- a/src/dom-to-image-more.js
+++ b/src/dom-to-image-more.js
@@ -1082,6 +1082,7 @@
             isHTMLTextAreaElement: isHTMLTextAreaElement,
             isShadowSlotElement: isShadowSlotElement,
             isSVGElement: isSVGElement,
+            isSVGImageElement: isSVGImageElement,
             isSVGSVGElement: isSVGSVGElement,
             isSVGRectElement: isSVGRectElement,
             isSVGUseElement: isSVGUseElement,
@@ -1150,6 +1151,10 @@
 
         function isHTMLImageElement(value) {
             return isInstanceOf(value, 'HTMLImageElement');
+        }
+
+        function isSVGImageElement(value) {
+            return isInstanceOf(value, 'SVGImageElement');
         }
 
         function isHTMLInputElement(value) {
@@ -1769,6 +1774,32 @@
             }
         }
 
+        // An SVG <image> references its bitmap via href / xlink:href (not .src like
+        // an HTML <img>), so newImage misses it and the external URL would survive
+        // unfetchable in the standalone output (#121). Inline it the same way: fetch
+        // and rewrite both href forms to a data URL. Mirrors the graceful contract —
+        // a failed fetch is surfaced via onImageError (inside getAndEncode) and the
+        // node is left as-is rather than sinking the whole render.
+        function inlineSvgImage(node, get) {
+            const XLINK_NS = 'http://www.w3.org/1999/xlink';
+            const href =
+                node.getAttribute('href') ||
+                node.getAttributeNS(XLINK_NS, 'href') ||
+                node.getAttribute('xlink:href');
+            if (!href || util.isDataUrl(href)) {
+                return Promise.resolve(node);
+            }
+            return Promise.resolve(href)
+                .then(get || util.getAndEncode)
+                .then(function (dataUrl) {
+                    if (dataUrl) {
+                        node.setAttributeNS(XLINK_NS, 'xlink:href', dataUrl);
+                        node.setAttribute('href', dataUrl);
+                    }
+                    return node;
+                });
+        }
+
         function inlineAll(node) {
             if (!util.isElement(node)) {
                 return Promise.resolve(node);
@@ -1777,6 +1808,8 @@
             return inlineCSSProperty(node).then(function () {
                 if (util.isHTMLImageElement(node)) {
                     return newImage(node).inline();
+                } else if (util.isSVGImageElement(node)) {
+                    return inlineSvgImage(node);
                 } else {
                     return Promise.all(
                         util.asArray(node.childNodes).map(function (child) {


### PR DESCRIPTION
An SVG `<image>` references its bitmap via `href/xlink:href`, add `util.isSVGImageElement` and an `inlineSvgImage` call that fetches the `href` and rewrites both `href` forms to a data URL, mirroring the graceful `onImageError` contract.

Fixes #121 